### PR TITLE
Add command to fetch a copy of the starboard database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .env
+venv
 .vscode
 .idea
 *.db
 *.log
 .python-version
+__pycache__

--- a/compscibot/handlers/commands.py
+++ b/compscibot/handlers/commands.py
@@ -72,9 +72,7 @@ async def randompost(ctx: commands.Context):
         except (discord.NotFound, discord.Forbidden):
             continue
     else:
-        await ctx.reply(
-            ":frowning: Seems the message I grabbed couldn't be found."
-        )
+        await ctx.reply(":frowning: Seems the message I grabbed couldn't be found.")
         return
 
     (attachment_links, embed) = construct_starboard_message(message)
@@ -82,3 +80,10 @@ async def randompost(ctx: commands.Context):
     await ctx.send(embed=embed)
     if attachment_links != "":
         await ctx.send("**Attached links:**\n\n" + str(attachment_links))
+
+
+@bot.command()
+async def database(ctx: commands.Context):
+    """Get a copy of the bot database."""
+
+    await ctx.send(file=discord.File("bot.db"))


### PR DESCRIPTION
# Changes
Add a new command, `c!database`, which when ran returns a copy of the database that is used to store starboard data. This can be used to implement #10 without needing to include the markdown-specific code in this repo, and is how this same kind of thing was implemented for [scribe](https://github.com/nint8835/scribe/commit/44bfc5d861e37f2339c0c0492a6f0b6bc008abd1)

# Testing
Ran locally, tested running `ct!database` (prefix was set to `ct!`), and the bot successfully sent me a copy of the database.